### PR TITLE
feature: fstrm 0.2.0 protocol (bi-directional connections)

### DIFF
--- a/framestream.go
+++ b/framestream.go
@@ -22,6 +22,8 @@ import "errors"
 const CONTROL_ACCEPT                = 0x01
 const CONTROL_START                 = 0x02
 const CONTROL_STOP                  = 0x03
+const CONTROL_READY                 = 0x04
+const CONTROL_FINISH                = 0x05
 
 const CONTROL_FIELD_CONTENT_TYPE    = 0x01
 
@@ -33,3 +35,4 @@ var ErrContentTypeMismatch = errors.New("content type mismatch")
 var ErrDataFrameTooLarge = errors.New("data frame too large")
 var ErrShortRead = errors.New("short read")
 var ErrDecode = errors.New("decoding error")
+var ErrType = errors.New("invalid type")


### PR DESCRIPTION
This patch implements most of `fstrm` `0.2.0` protocol, notably, bi-directional connections. This is as a prerequisite for pending `golang-dnstap` pull request to support unix sockets.

I left the method parameters the same, to be backwards compatible with current `golang-dnstap` version. Also, tried to keep the code style as it was.
