### PR TITLE
Add a bidirectional encoder and a (passing) socket test

### DIFF
--- a/Decoder.go
+++ b/Decoder.go
@@ -52,7 +52,7 @@ func NewBidirectionalDecoder(rw io.ReadWriter, opt *DecoderOptions) (dec *Decode
 	}
 
 	// Check content type.
-	matched := MatchContentTypes(cf.ContentTypes, [][]byte{dec.opt.ContentType})
+	matched := matchContentTypes(cf.ContentTypes, [][]byte{dec.opt.ContentType})
 	if len(matched) != 1 {
 		return dec, ErrContentTypeMismatch
 	}
@@ -97,7 +97,7 @@ func startDecoder(dec *Decoder) error {
 	}
 
 	// Check content type.
-	matched := MatchContentTypes(cf.ContentTypes, [][]byte{dec.opt.ContentType})
+	matched := matchContentTypes(cf.ContentTypes, [][]byte{dec.opt.ContentType})
 	if len(matched) != 1 {
 		return ErrContentTypeMismatch
 	}
@@ -105,7 +105,7 @@ func startDecoder(dec *Decoder) error {
 	return nil
 }
 
-func ReadBE32(r io.Reader) (val uint32, err error) {
+func readBE32(r io.Reader) (val uint32, err error) {
 	err = binary.Read(r, binary.BigEndian, &val)
 	if err != nil {
 		return 0, err
@@ -114,11 +114,11 @@ func ReadBE32(r io.Reader) (val uint32, err error) {
 }
 
 func (dec *Decoder) readBE32() (val uint32, err error) {
-	return ReadBE32(dec.reader)
+	return readBE32(dec.reader)
 }
 
 func readEscape(r io.Reader) error {
-	escape, err := ReadBE32(r)
+	escape, err := readBE32(r)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func readControlFrame(reader io.Reader) (cf *ControlFrame, err error) {
 	cf = new(ControlFrame)
 
 	// Read the control frame length.
-	controlFrameLen, err := ReadBE32(reader)
+	controlFrameLen, err := readBE32(reader)
 	if err != nil {
 		return
 	}
@@ -213,7 +213,7 @@ func readControlFrame(reader io.Reader) (cf *ControlFrame, err error) {
 	return
 }
 
-func MatchContentTypes(a [][]byte, b [][]byte) (c [][]byte) {
+func matchContentTypes(a [][]byte, b [][]byte) (c [][]byte) {
 	matched := make([][]byte, 0, 0)
 	for _, contentTypeA := range a {
 		for _, contentTypeB := range b {

--- a/Encoder.go
+++ b/Encoder.go
@@ -54,7 +54,7 @@ func NewBidirectionalEncoder(rw io.ReadWriter, opt *EncoderOptions) (enc *Encode
 	}
 
 	// Check content type.
-	matched := MatchContentTypes(cf.ContentTypes, [][]byte{opt.ContentType})
+	matched := matchContentTypes(cf.ContentTypes, [][]byte{opt.ContentType})
 	if len(matched) != 1 {
 		return enc, ErrContentTypeMismatch
 	}

--- a/Encoder.go
+++ b/Encoder.go
@@ -18,8 +18,8 @@ package framestream
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/binary"
+	"github.com/pkg/errors"
 	"io"
 )
 
@@ -33,7 +33,41 @@ type Encoder struct {
 	buf    []byte
 }
 
-func NewEncoder(w io.Writer, opt *EncoderOptions) (enc *Encoder, err error) {
+func NewBidirectionalEncoder(rw io.ReadWriter, opt *EncoderOptions) (enc *Encoder, err error) {
+	enc = newEncoder(rw, opt)
+
+	// Write the ready control frame.
+	cf := &ControlFrame{ControlType: CONTROL_READY}
+	if opt.ContentType != nil {
+		cf.ContentTypes = [][]byte{opt.ContentType}
+	}
+	if err = writeControlFrameBuf(enc.writer, cf); err != nil {
+		err = errors.Wrap(err, "write the ready control frame")
+		return
+	}
+
+	// Wait for the accept control frame.
+	cf, err = readControlFrameType(rw, CONTROL_ACCEPT)
+	if err != nil {
+		err = errors.Wrap(err, "wait accept control frame")
+		return
+	}
+
+	// Check content type.
+	matched := MatchContentTypes(cf.ContentTypes, [][]byte{opt.ContentType})
+	if len(matched) != 1 {
+		return enc, ErrContentTypeMismatch
+	}
+
+	return enc, startEncoder(enc)
+}
+
+// Write the start control frame.
+func startEncoder(enc *Encoder) error {
+	return errors.Wrap(enc.writeControlStart(),
+		"write the start control frame")
+}
+func newEncoder(w io.Writer, opt *EncoderOptions) (enc *Encoder) {
 	if opt == nil {
 		opt = &EncoderOptions{}
 	}
@@ -41,14 +75,13 @@ func NewEncoder(w io.Writer, opt *EncoderOptions) (enc *Encoder, err error) {
 		writer: bufio.NewWriter(w),
 		opt:    *opt,
 	}
+	return enc
+}
 
-	// Write the start control frame.
-	err = enc.writeControlStart()
-	if err != nil {
-		return
-	}
+func NewEncoder(w io.Writer, opt *EncoderOptions) (*Encoder, error) {
+	enc := newEncoder(w, opt)
+	return enc, startEncoder(enc)
 
-	return
 }
 
 func (enc *Encoder) Close() error {
@@ -56,115 +89,16 @@ func (enc *Encoder) Close() error {
 }
 
 func (enc *Encoder) writeControlStart() (err error) {
-	totalLen := 0
-
-	// Calculate the total amount of space needed for the control frame.
-
-	// Escape: 32-bit BE integer. Zero.
-	totalLen += 4
-
-	// Frame length: 32-bit BE integer.
-	totalLen += 4
-
-	// Control type: 32-bit BE integer.
-	totalLen += 4
-
+	cf := ControlFrame{ControlType: CONTROL_START}
 	if enc.opt.ContentType != nil {
-		// CONTROL_FIELD_CONTENT_TYPE: 32-bit BE integer.
-		totalLen += 4
-
-		// Length of content type string: 32-bit BE integer.
-		totalLen += 4
-
-		// The content type string itself.
-		totalLen += len(enc.opt.ContentType)
+		cf.ContentTypes = [][]byte{enc.opt.ContentType}
 	}
-
-	// Allocate the storage for the control frame.
-	buf := new(bytes.Buffer)
-
-	// Now actually serialize the control frame.
-
-	// Escape: 32-bit BE integer. Zero.
-	err = binary.Write(buf, binary.BigEndian, uint32(0))
-	if err != nil {
-		return
-	}
-
-	// Frame length: 32-bit BE integer.
-	//
-	// This does not include the length of the escape frame or the length of
-	// the frame length field itself, so subtract 2*4 bytes from the total
-	// length.
-	err = binary.Write(buf, binary.BigEndian, uint32(totalLen-2*4))
-	if err != nil {
-		return
-	}
-
-	// Control type: 32-bit BE integer.
-	err = binary.Write(buf, binary.BigEndian, uint32(CONTROL_START))
-	if err != nil {
-		return
-	}
-
-	if enc.opt.ContentType != nil {
-		// FSTRM_CONTROL_FIELD_CONTENT_TYPE: 32-bit BE integer.
-		err = binary.Write(buf, binary.BigEndian, uint32(CONTROL_FIELD_CONTENT_TYPE))
-		if err != nil {
-			return
-		}
-
-		// Length of content type string: 32-bit BE integer.
-		err = binary.Write(buf, binary.BigEndian, uint32(len(enc.opt.ContentType)))
-		if err != nil {
-			return
-		}
-
-		// The content type string itself.
-		_, err = buf.Write(enc.opt.ContentType)
-		if err != nil {
-			return
-		}
-	}
-
-	// Write the control frame.
-	_, err = buf.WriteTo(enc.writer)
-	if err != nil {
-		return
-	}
-
-	return enc.Flush()
+	return writeControlFrameBuf(enc.writer, &cf)
 }
 
 func (enc *Encoder) writeControlStop() (err error) {
-	totalLen := 3 * 4
-	buf := new(bytes.Buffer)
-
-	// Escape: 32-bit BE integer. Zero.
-	err = binary.Write(buf, binary.BigEndian, uint32(0))
-	if err != nil {
-		return
-	}
-
-	// Frame length: 32-bit BE integer.
-	err = binary.Write(buf, binary.BigEndian, uint32(totalLen-2*4))
-	if err != nil {
-		return
-	}
-
-	// Control type: 32-bit BE integer.
-	err = binary.Write(buf, binary.BigEndian, uint32(CONTROL_STOP))
-	if err != nil {
-		return
-	}
-
-	// Write the control frame.
-	_, err = buf.WriteTo(enc.writer)
-	if err != nil {
-		return
-	}
-
-	return enc.Flush()
+	cf := ControlFrame{ControlType: CONTROL_STOP}
+	return writeControlFrameBuf(enc.writer, &cf)
 }
 
 func (enc *Encoder) Write(frame []byte) (n int, err error) {

--- a/pkg_test.go
+++ b/pkg_test.go
@@ -42,7 +42,11 @@ func TestSocket(t *testing.T) {
 			return
 		}
 
-		dec, err := NewBidirectionalDecoder(server, &DecoderOptions{ContentType: FSContentType})
+		opt := &DecoderOptions{
+			ContentType:   FSContentType,
+			Bidirectional: true,
+		}
+		dec, err := NewDecoder(server, opt)
 		if err != nil {
 			t.Fatal(err)
 			return
@@ -60,7 +64,11 @@ func TestSocket(t *testing.T) {
 			return
 		}
 
-		enc, err = NewBidirectionalEncoder(client, &EncoderOptions{ContentType: FSContentType})
+		opt := &EncoderOptions{
+			ContentType:   FSContentType,
+			Bidirectional: true,
+		}
+		enc, err = NewEncoder(client, opt)
 		if err != nil {
 			t.Fatal(err)
 			return

--- a/pkg_test.go
+++ b/pkg_test.go
@@ -1,0 +1,98 @@
+package framestream
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+var FSContentType = []byte("protobuf:dnstap.Dnstap")
+
+func TestUnidirectional(t *testing.T) {
+	b := &bytes.Buffer{}
+
+	enc, err := NewEncoder(b, &EncoderOptions{ContentType: FSContentType})
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	dec, err := NewDecoder(b, &DecoderOptions{ContentType: FSContentType})
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	testEncodeDecode(t, enc, dec)
+}
+func TestSocket(t *testing.T) {
+	var enc *Encoder
+	wait := make(chan bool)
+
+	l, err := net.Listen("unix", "sock")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	go func() {
+		server, err := l.Accept()
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+
+		dec, err := NewBidirectionalDecoder(server, &DecoderOptions{ContentType: FSContentType})
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+
+		testEncodeDecode(t, enc, dec)
+
+		close(wait)
+	}()
+
+	if !t.Failed() {
+		client, err := net.Dial("unix", "sock")
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+
+		enc, err = NewBidirectionalEncoder(client, &EncoderOptions{ContentType: FSContentType})
+		if err != nil {
+			t.Fatal(err)
+			return
+		}
+
+		<-wait
+	}
+
+	if err := l.Close(); err != nil {
+		t.Error(err)
+	}
+}
+
+func testEncodeDecode(t *testing.T, enc *Encoder, dec *Decoder) {
+	wants := []string{"frame one", "two", "3"}
+	for _, frame := range wants {
+		_, err := enc.Write([]byte(frame))
+		if err != nil {
+			t.Fatalf("encode failed: %s\n", err)
+			return
+		}
+	}
+	enc.Flush()
+	enc.Close()
+
+	for i, want := range wants {
+		frame, err := dec.Decode()
+		if err != nil {
+			t.Errorf("decode failed: %s\n", err)
+		}
+		if string(frame) != want {
+			t.Errorf("frame %d: wanted: %s, got: %s", i, wants[i], string(frame))
+		}
+	}
+}


### PR DESCRIPTION
The unidrectional test is still passing, the new bidirectional encoder is inspired from the C library, and a test show it working over a socket.

A dnstap enabled Go server needs it to send its data over a socket.

Also removed the `interface{}` parameters, I hope it complies with the undocumented bidirectional framestream protocol!

[Please see this usage exemple.](https://github.com/varyoo/golang-framestream/blob/54e86b9ea446e5b35655e93d9b061867c2060014/pkg_test.go#L28)