### PR TITLE
framestream_dump: remove usage of deprecated decoder fields.

### DIFF
--- a/framestream_dump/main.go
+++ b/framestream_dump/main.go
@@ -45,8 +45,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Print the frames.
-	fmt.Printf("Control frame [START] (%v bytes): %x\n", len(fs.ControlStart), fs.ControlStart)
+	// Print the data frames.
 	for {
 		frame, err := fs.Decode()
 		if err == framestream.EOF {
@@ -56,8 +55,5 @@ func main() {
 			log.Fatal(err)
 		}
 		fmt.Printf("Data frame (%v bytes): %x\n", len(frame), frame)
-	}
-	if fs.ControlStop != nil {
-		fmt.Printf("Control frame [STOP] (%v bytes): %x\n", len(fs.ControlStop), fs.ControlStop)
 	}
 }


### PR DESCRIPTION
Commit b600ccf606747139c84b6d69b5c3988164db4d42 removed the control frame fields from the Decoder structure. Remove them from framestream_dump also.