### PR TITLE
Reader-Writer

### DIFF
--- a/Control.go
+++ b/Control.go
@@ -163,8 +163,12 @@ func (c *ControlFrame) ChooseContentType(ctypes [][]byte) (typ []byte, found boo
 }
 
 func (c *ControlFrame) MatchContentType(ctype []byte) bool {
-	_, ok := c.ChooseContentType([][]byte{ctype})
-	return ok
+	for _, cfctype := range c.ContentTypes {
+		if bytes.Compare(ctype, cfctype) == 0 {
+			return true
+		}
+	}
+	return len(c.ContentTypes) == 0
 }
 
 func (c *ControlFrame) SetContentTypes(ctypes [][]byte) {

--- a/Control.go
+++ b/Control.go
@@ -178,5 +178,7 @@ func (c *ControlFrame) SetContentTypes(ctypes [][]byte) {
 func (c *ControlFrame) SetContentType(ctype []byte) {
 	if ctype != nil {
 		c.SetContentTypes([][]byte{ctype})
+	} else {
+		c.ContentTypes = nil
 	}
 }

--- a/Control.go
+++ b/Control.go
@@ -15,6 +15,8 @@ const CONTROL_FINISH = 0x05
 
 const CONTROL_FIELD_CONTENT_TYPE = 0x01
 
+const CONTROL_FRAME_LENGTH_MAX = 512
+
 type ControlFrame struct {
 	ControlType  uint32
 	ContentTypes [][]byte
@@ -73,6 +75,14 @@ func (c *ControlFrame) Decode(r io.Reader) (err error) {
 	err = binary.Read(r, binary.BigEndian, &cflen)
 	if err != nil {
 		return
+	}
+
+	if cflen > CONTROL_FRAME_LENGTH_MAX {
+		return ErrDecode
+	}
+
+	if cflen < 4 {
+		return ErrDecode
 	}
 
 	err = binary.Read(r, binary.BigEndian, &c.ControlType)

--- a/Decoder.go
+++ b/Decoder.go
@@ -40,11 +40,14 @@ func NewDecoder(r io.Reader, opt *DecoderOptions) (*Decoder, error) {
 	if opt.MaxPayloadSize == 0 {
 		opt.MaxPayloadSize = DEFAULT_MAX_PAYLOAD_SIZE
 	}
-	dr, err := NewReader(r, &ReaderOptions{
+	ropt := &ReaderOptions{
 		Bidirectional: opt.Bidirectional,
-		ContentType:   opt.ContentType,
 		Timeout:       opt.Timeout,
-	})
+	}
+	if opt.ContentType != nil {
+		ropt.ContentTypes = append(ropt.ContentTypes, opt.ContentType)
+	}
+	dr, err := NewReader(r, ropt)
 	if err != nil {
 		return nil, err
 	}

--- a/Decoder.go
+++ b/Decoder.go
@@ -82,7 +82,7 @@ func NewDecoder(r io.Reader, opt *DecoderOptions) (*Decoder, error) {
 // Decode returns the data from a Frame Streams data frame. The slice returned
 // is valid until the next call to Decode.
 func (dec *Decoder) Decode() (frameData []byte, err error) {
-	n, err := dec.r.Read(dec.buf)
+	n, err := dec.r.ReadFrame(dec.buf)
 	if err != nil {
 		return nil, err
 	}

--- a/Decoder.go
+++ b/Decoder.go
@@ -17,8 +17,6 @@
 package framestream
 
 import (
-	"bufio"
-	"encoding/binary"
 	"io"
 	"time"
 )
@@ -31,130 +29,36 @@ type DecoderOptions struct {
 }
 
 type Decoder struct {
-	buf     []byte
-	opt     DecoderOptions
-	reader  *bufio.Reader
-	writer  *bufio.Writer
-	stopped bool
+	buf []byte
+	r   *Reader
 }
 
-func NewDecoder(r io.Reader, opt *DecoderOptions) (dec *Decoder, err error) {
+func NewDecoder(r io.Reader, opt *DecoderOptions) (*Decoder, error) {
 	if opt == nil {
 		opt = &DecoderOptions{}
 	}
 	if opt.MaxPayloadSize == 0 {
 		opt.MaxPayloadSize = DEFAULT_MAX_PAYLOAD_SIZE
 	}
-	r = timeoutReader(r, opt)
-	dec = &Decoder{
-		buf:    make([]byte, opt.MaxPayloadSize),
-		opt:    *opt,
-		reader: bufio.NewReader(r),
-		writer: nil,
-	}
-
-	var cf ControlFrame
-	if opt.Bidirectional {
-		w, ok := r.(io.Writer)
-		if !ok {
-			return dec, ErrType
-		}
-		dec.writer = bufio.NewWriter(w)
-
-		// Read the ready control frame.
-		err = cf.DecodeTypeEscape(dec.reader, CONTROL_READY)
-		if err != nil {
-			return
-		}
-
-		// Check content type.
-		if !cf.MatchContentType(dec.opt.ContentType) {
-			return dec, ErrContentTypeMismatch
-		}
-
-		// Send the accept control frame.
-		accept := ControlAccept
-		accept.SetContentType(dec.opt.ContentType)
-		err = accept.EncodeFlush(dec.writer)
-		if err != nil {
-			return
-		}
-	}
-
-	// Read the start control frame.
-	err = cf.DecodeTypeEscape(dec.reader, CONTROL_START)
+	dr, err := NewReader(r, &ReaderOptions{
+		Bidirectional: opt.Bidirectional,
+		ContentType:   opt.ContentType,
+		Timeout:       opt.Timeout,
+	})
 	if err != nil {
-		return
+		return nil, err
 	}
-
-	// Disable the read timeout to prevent killing idle connections.
-	disableReadTimeout(r)
-
-	// Check content type.
-	if !cf.MatchContentType(dec.opt.ContentType) {
-		return dec, ErrContentTypeMismatch
+	dec := &Decoder{
+		buf: make([]byte, opt.MaxPayloadSize),
+		r:   dr,
 	}
-
-	return
-}
-
-func (dec *Decoder) readFrame(frameLen uint32) (err error) {
-	// Enforce limits on frame size.
-	if frameLen > dec.opt.MaxPayloadSize {
-		err = ErrDataFrameTooLarge
-		return
-	}
-
-	// Read the frame.
-	n, err := io.ReadFull(dec.reader, dec.buf[0:frameLen])
-	if err != nil || uint32(n) != frameLen {
-		return
-	}
-	return
+	return dec, nil
 }
 
 func (dec *Decoder) Decode() (frameData []byte, err error) {
-	if dec.stopped {
-		err = EOF
-		return
-	}
-
-	// Read the frame length.
-	var frameLen uint32
-	err = binary.Read(dec.reader, binary.BigEndian, &frameLen)
+	n, err := dec.r.Read(dec.buf)
 	if err != nil {
-		return
+		return nil, err
 	}
-	if frameLen == 0 {
-		// This is a control frame.
-		var cf ControlFrame
-		err = cf.Decode(dec.reader)
-		if err != nil {
-			return
-		}
-		if cf.ControlType == CONTROL_STOP {
-			dec.stopped = true
-			if dec.opt.Bidirectional {
-				ff := &ControlFrame{ControlType: CONTROL_FINISH}
-				err = ff.EncodeFlush(dec.writer)
-				if err != nil {
-					return
-				}
-			}
-			return nil, EOF
-		}
-		if err != nil {
-			return nil, err
-		}
-
-	} else {
-		// This is a data frame.
-		err = dec.readFrame(frameLen)
-		if err != nil {
-			return
-		}
-		frameData = dec.buf[0:frameLen]
-	}
-
-	return
+	return dec.buf[:n], nil
 }

--- a/Encoder.go
+++ b/Encoder.go
@@ -21,16 +21,32 @@ import (
 	"time"
 )
 
+// EncoderOptions specifies configuration for an Encoder
 type EncoderOptions struct {
-	ContentType   []byte
+	// The ContentType of the data sent by the Encoder. May be left unset
+	// for no content negotiation. If the Reader requests a different
+	// content type, NewEncoder() will return ErrContentTypeMismatch.
+	ContentType []byte
+	// If Bidirectional is true, the underlying io.Writer must be an
+	// io.ReadWriter, and the Encoder will engage in a bidirectional
+	// handshake with its peer to establish content type and communicate
+	// shutdown.
 	Bidirectional bool
-	Timeout       time.Duration
+	// Timeout gives the timeout for writing both control and data frames,
+	// and for reading responses to control frames sent. It is only
+	//  effective for underlying Writers satisfying net.Conn.
+	Timeout time.Duration
 }
 
+// An Encoder sends data frames over a FrameStream Writer.
+//
+// Encoder is provided for compatibility, use Writer instead.
 type Encoder struct {
 	*Writer
 }
 
+// NewEncoder creates an Encoder writing to the given io.Writer with the given
+// EncoderOptions.
 func NewEncoder(w io.Writer, opt *EncoderOptions) (enc *Encoder, err error) {
 	if opt == nil {
 		opt = &EncoderOptions{}

--- a/Encoder.go
+++ b/Encoder.go
@@ -64,3 +64,7 @@ func NewEncoder(w io.Writer, opt *EncoderOptions) (enc *Encoder, err error) {
 	}
 	return &Encoder{Writer: writer}, nil
 }
+
+func (e *Encoder) Write(frame []byte) (int, error) {
+	return e.WriteFrame(frame)
+}

--- a/Encoder.go
+++ b/Encoder.go
@@ -35,13 +35,14 @@ func NewEncoder(w io.Writer, opt *EncoderOptions) (enc *Encoder, err error) {
 	if opt == nil {
 		opt = &EncoderOptions{}
 	}
-	writer, err := NewWriter(w,
-		&WriterOptions{
-			ContentType:   opt.ContentType,
-			Bidirectional: opt.Bidirectional,
-			Timeout:       opt.Timeout,
-		})
-
+	wopt := &WriterOptions{
+		Bidirectional: opt.Bidirectional,
+		Timeout:       opt.Timeout,
+	}
+	if opt.ContentType != nil {
+		wopt.ContentTypes = append(wopt.ContentTypes, opt.ContentType)
+	}
+	writer, err := NewWriter(w, wopt)
 	if err != nil {
 		return nil, err
 	}

--- a/Reader.go
+++ b/Reader.go
@@ -116,11 +116,11 @@ func NewReader(r io.Reader, opt *ReaderOptions) (*Reader, error) {
 	return reader, nil
 }
 
-// Read reads a data frame into the supplied buffer, returning its length.
+// ReadFrame reads a data frame into the supplied buffer, returning its length.
 // If the frame is longer than the supplied buffer, Read returns
 // ErrDataFrameTooLarge and discards the frame. Subsequent calls to Read()
 // after this error may succeed.
-func (r *Reader) Read(b []byte) (length int, err error) {
+func (r *Reader) ReadFrame(b []byte) (length int, err error) {
 	if r.stopped {
 		return 0, EOF
 	}

--- a/Reader.go
+++ b/Reader.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"io"
 	"io/ioutil"
-	"log"
 	"time"
 )
 
@@ -79,7 +78,6 @@ func NewReader(r io.Reader, opt *ReaderOptions) (*Reader, error) {
 		// Read the ready control frame.
 		err := cf.DecodeTypeEscape(reader.r, CONTROL_READY)
 		if err != nil {
-			log.Println("DecodeTypeEscape: ", err)
 			return nil, err
 		}
 

--- a/Reader.go
+++ b/Reader.go
@@ -64,7 +64,7 @@ func NewReader(r io.Reader, opt *ReaderOptions) (*Reader, error) {
 		w:             nil,
 	}
 
-	if opt.ContentTypes != nil {
+	if len(opt.ContentTypes) > 0 {
 		reader.contentType = opt.ContentTypes[0]
 	}
 

--- a/Reader.go
+++ b/Reader.go
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2014 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package framestream
+
+import (
+	"bufio"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
+	"time"
+)
+
+type ReaderOptions struct {
+	ContentType   []byte
+	Bidirectional bool
+	Timeout       time.Duration
+}
+
+type Reader struct {
+	contentType   []byte
+	bidirectional bool
+	r             *bufio.Reader
+	w             *bufio.Writer
+	stopped       bool
+}
+
+func NewReader(r io.Reader, opt *ReaderOptions) (*Reader, error) {
+	if opt == nil {
+		opt = &ReaderOptions{}
+	}
+	tr := timeoutReader(r, opt)
+	reader := &Reader{
+		bidirectional: opt.Bidirectional,
+		r:             bufio.NewReader(tr),
+		w:             nil,
+	}
+
+	var cf ControlFrame
+	if opt.Bidirectional {
+		w, ok := tr.(io.Writer)
+		if !ok {
+			return nil, ErrType
+		}
+		reader.w = bufio.NewWriter(w)
+
+		// Read the ready control frame.
+		err := cf.DecodeTypeEscape(reader.r, CONTROL_READY)
+		if err != nil {
+			return nil, err
+		}
+
+		// Check content type.
+		if !cf.MatchContentType(opt.ContentType) {
+			return nil, ErrContentTypeMismatch
+		}
+
+		// Send the accept control frame.
+		accept := ControlAccept
+		accept.SetContentType(opt.ContentType)
+		err = accept.EncodeFlush(reader.w)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Read the start control frame.
+	err := cf.DecodeTypeEscape(reader.r, CONTROL_START)
+	if err != nil {
+		return nil, err
+	}
+
+	// Disable the read timeout to prevent killing idle connections.
+	disableReadTimeout(tr)
+
+	// Check content type.
+	if !cf.MatchContentType(opt.ContentType) {
+		return nil, ErrContentTypeMismatch
+	}
+
+	return reader, nil
+}
+
+func (r *Reader) Read(b []byte) (n int, err error) {
+	if r.stopped {
+		return 0, EOF
+	}
+
+	for n == 0 {
+		n, err = r.readFrame(b)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func (r *Reader) readFrame(b []byte) (int, error) {
+	// Read the frame length.
+	var frameLen uint32
+	err := binary.Read(r.r, binary.BigEndian, &frameLen)
+	if err != nil {
+		return 0, err
+	}
+
+	if frameLen > uint32(len(b)) {
+		io.CopyN(ioutil.Discard, r.r, int64(frameLen))
+		return 0, ErrDataFrameTooLarge
+	}
+
+	if frameLen == 0 {
+		// This is a control frame.
+		var cf ControlFrame
+		err = cf.Decode(r.r)
+		if err != nil {
+			return 0, err
+		}
+		if cf.ControlType == CONTROL_STOP {
+			r.stopped = true
+			if r.bidirectional {
+				ff := &ControlFrame{ControlType: CONTROL_FINISH}
+				err = ff.EncodeFlush(r.w)
+				if err != nil {
+					return 0, err
+				}
+			}
+			return 0, EOF
+		}
+		return 0, err
+	}
+
+	return io.ReadFull(r.r, b[0:frameLen])
+}

--- a/Writer.go
+++ b/Writer.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2014 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package framestream
+
+import (
+	"bufio"
+	"encoding/binary"
+	"io"
+	"time"
+)
+
+type WriterOptions struct {
+	ContentType   []byte
+	Bidirectional bool
+	Timeout       time.Duration
+}
+
+type Writer struct {
+	writer *bufio.Writer
+	reader *bufio.Reader
+	opt    WriterOptions
+	buf    []byte
+}
+
+func NewWriter(w io.Writer, opt *WriterOptions) (wr *Writer, err error) {
+	if opt == nil {
+		opt = &WriterOptions{}
+	}
+	w = timeoutWriter(w, opt)
+	wr = &Writer{
+		writer: bufio.NewWriter(w),
+		opt:    *opt,
+	}
+
+	if opt.Bidirectional {
+		r, ok := w.(io.Reader)
+		if !ok {
+			return nil, ErrType
+		}
+		wr.reader = bufio.NewReader(r)
+		ready := ControlReady
+		ready.SetContentType(opt.ContentType)
+		if err = ready.EncodeFlush(wr.writer); err != nil {
+			return
+		}
+
+		var accept ControlFrame
+		if err = accept.DecodeTypeEscape(wr.reader, CONTROL_ACCEPT); err != nil {
+			return
+		}
+
+		if !accept.MatchContentType(opt.ContentType) {
+			return nil, ErrContentTypeMismatch
+		}
+	}
+
+	// Write the start control frame.
+	start := ControlStart
+	start.SetContentType(opt.ContentType)
+	err = start.EncodeFlush(wr.writer)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (wr *Writer) Close() (err error) {
+	err = ControlStop.EncodeFlush(wr.writer)
+	if err != nil || !wr.opt.Bidirectional {
+		return
+	}
+
+	var finish ControlFrame
+	return finish.DecodeTypeEscape(wr.reader, CONTROL_FINISH)
+}
+
+func (wr *Writer) Write(frame []byte) (n int, err error) {
+	err = binary.Write(wr.writer, binary.BigEndian, uint32(len(frame)))
+	if err != nil {
+		return
+	}
+	return wr.writer.Write(frame)
+}
+
+func (wr *Writer) Flush() error {
+	return wr.writer.Flush()
+}

--- a/Writer.go
+++ b/Writer.go
@@ -60,7 +60,7 @@ func NewWriter(w io.Writer, opt *WriterOptions) (writer *Writer, err error) {
 		opt: *opt,
 	}
 
-	if opt.ContentTypes != nil {
+	if len(opt.ContentTypes) > 0 {
 		writer.contentType = opt.ContentTypes[0]
 	}
 

--- a/Writer.go
+++ b/Writer.go
@@ -117,9 +117,9 @@ func (w *Writer) Close() (err error) {
 	return finish.DecodeTypeEscape(w.r, CONTROL_FINISH)
 }
 
-// Write writes the given frame to the underlying io.Writer with Frame Streams
+// WriteFrame writes the given frame to the underlying io.Writer with Frame Streams
 // framing.
-func (w *Writer) Write(frame []byte) (n int, err error) {
+func (w *Writer) WriteFrame(frame []byte) (n int, err error) {
 	err = binary.Write(w.w, binary.BigEndian, uint32(len(frame)))
 	if err != nil {
 		return

--- a/timeout.go
+++ b/timeout.go
@@ -25,7 +25,7 @@ func (toc *timeoutConn) Read(b []byte) (int, error) {
 	return toc.conn.Read(b)
 }
 
-func timeoutWriter(w io.Writer, opt *EncoderOptions) io.Writer {
+func timeoutWriter(w io.Writer, opt *WriterOptions) io.Writer {
 	if !opt.Bidirectional {
 		return w
 	}
@@ -42,7 +42,7 @@ func timeoutWriter(w io.Writer, opt *EncoderOptions) io.Writer {
 	return w
 }
 
-func timeoutReader(r io.Reader, opt *DecoderOptions) io.Reader {
+func timeoutReader(r io.Reader, opt *ReaderOptions) io.Reader {
 	if !opt.Bidirectional {
 		return r
 	}


### PR DESCRIPTION
Adds new Reader and Writer APIs.

Reader is similar to Decoder, except it reads the frame into a user-supplied buffer to reduce  the need for copying. Reader and Writer also support specifying multiple alternative content types, while Decoder and Encoder only allow a single value.

Added godoc documentation to Encoder, Decoder, Reader, and Writer.